### PR TITLE
Don't ignore failure to open/read /dev/urandom.

### DIFF
--- a/raru.c
+++ b/raru.c
@@ -25,7 +25,10 @@ int main(int argc, char **argv) {
 	if (argc == 1)
 		usageQuit();
 	fd = open("/dev/urandom", O_RDONLY);
-	read(fd, &random, sizeof(random));
+	if (fd == -1)
+		failQuit("Unable to open /dev/urandom");
+	if (read(fd, &random, sizeof(random)) != sizeof(random))
+		failQuit("Unable to read from /dev/urandom");
 	close(fd);
 
 	/* Don't mess with NULL pointers. This is setuid, afterall.     */


### PR DESCRIPTION
In some environments, /dev/urandom is unavailable. Prior to this commit failure
to open or read from /dev/urandom would not be noticed and raru would go on to
blindly use 0 as the "random" ID offset.

----

While I'm here, I don't follow why all the variables in this program are globals. Is there a reason not to make them local to `main`?